### PR TITLE
Add support for associating preview of the site with pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ This ``slicer-org`` branch of this repository store the static content served at
 Every 5 minutes, the branch [slicer-org](https://github.com/Slicer/slicer.org/tree/slicer-org) is automatically pulled into the live site. There is no need to
 connect to the server in order to make changes.
 
+# Pull Request preview
+
+A preview deployement of the site will automatically be setup using [netlify](https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/).
+
+The netlify deployment has been configured by [@jcfr](https://github.com/jcfr) and since the [free plan](https://www.netlify.com/pricing/) is being used, only one user can update its configuration.
+
 # Local Development
 
 1. [Fork][fork] this repository. We will assume your GitHub account is **yourname**.


### PR DESCRIPTION
Preview can be accessed clicking on the "Details" link:

![image](https://user-images.githubusercontent.com/219043/78860462-4423b180-7a00-11ea-9264-370cfd74f4cc.png)
