### PR TITLE
BUG: Fix link to Commercial-use internal page explicitly appending ".html"

### DIFF
--- a/_data/footer-site-map.yml
+++ b/_data/footer-site-map.yml
@@ -46,7 +46,7 @@ About:
   - name: Citing
     link: https://slicer.readthedocs.io/en/latest/user_guide/about.html#how-to-cite
   - name: Commercial Use
-    link: /Commercial-use
+    link: /Commercial-use.html
   - name: 3D Slicer Enabled Research
     link: https://www.slicer.org/wiki/Main_Page/SlicerCommunity
   - name: Acknowledgments

--- a/index.markdown
+++ b/index.markdown
@@ -137,7 +137,7 @@ commercial_use:
   title: Commercial Use
   description: We invite commercial entities to use 3D Slicer. 3D Slicer is a Free Open Source Software distributed under a BSD style license.<br> The license does not impose restrictions on the use of the software. For details, please see the <a href="https://www.slicer.org/wiki/License">3D Slicer Software License Agreement</a>.<br> Learn more about our commercial partners and 3D Slicer based products and product prototypes.
   button_text: Learn More
-  page_url: /Commercial-use
+  page_url: /Commercial-use.html
 
 # Community ======================================================
 community:


### PR DESCRIPTION
This commit workaround limitation of the current nginx server configuration
serving "slicer.org" pages.

See https://github.com/Slicer/slicer.org/pull/79#issuecomment-809697846

Reported-by: James Butler <jbutler@sonovol.com>