### PR TITLE
Force disabling for feed generation

### DIFF
--- a/_plugins/feed_generator_override.rb
+++ b/_plugins/feed_generator_override.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module JekyllFeed
+  class Generator < Jekyll::Generator
+    safe true
+    priority :lowest
+
+    # Main plugin action, called by Jekyll-core
+    def generate(_site)
+    end
+  end
+end


### PR DESCRIPTION
This commit is a follow up of 561c6eb01  (Disable unused "jekyll-feed" plugin)
to ensure feed generation is disabled.

Since jekyll-feed is a dependency of bulma-clean-theme, it is implicitly
enabled.

Without a setting to disable the feed generation, this commit applies the workaround
documented in https://github.com/jekyll/minima/issues/562#issuecomment-735120020

See #50