### PR TITLE
download: Fix jinja2 template associated with download_stats_url

### DIFF
--- a/_config_download.yml
+++ b/_config_download.yml
@@ -1,6 +1,6 @@
 
-# Set the flask template used in https://github.com/Slicer/slicer_download/blob/main/slicer_download_server/__init__.py
-slicer_download_stats_url: "{{ download_stats_url }}"
+# Set the jinja2 template intended to be used in https://github.com/Slicer/slicer_download
+slicer_download_stats_url: "{{download_stats_url}}"
 
 # Toggle use of "download_mock" specified in download.markdown
 slicer_download_mock_enabled: false

--- a/download.markdown
+++ b/download.markdown
@@ -28,7 +28,7 @@ download_mock:
     Read about <a href="https://slicer.readthedocs.io/en/latest/user_guide/getting_started.html#system-requirements">system requirements</a>.
     </div>
 
-    <!-- This section is a flask template intended to be used https://github.com/Slicer/slicer_download -->
+    <!-- This section contains jinja2 templates intended to be used in https://github.com/Slicer/slicer_download -->
     <h2>Installers</h2>
     <div class="columns is-mobile is-centered">
     <table class="installers column is-three-quarters">


### PR DESCRIPTION
This commit removes the extra space causing the following error when
using the generated download templates:

```
  File "/home/jcfr/Projects/slicer_download/slicer_download_server/templates/download.html", line 283, in template
    <a href="{{%20download_stats_url%20}}" class="navbar-item">
  jinja2.exceptions.TemplateSyntaxError: unexpected '%'
```