### PR TITLE
_includes/header: Fix "3D Slicer" link associated with download site

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
     <div class="container">
         <div class="navbar-brand">
             <img src="{{ site.logo_image }}" width="35">
-            <a href="{{ site.baseurl }}/" class="navbar-item">
+            <a href="{{ '/' | absolute_url }}" class="navbar-item">
                 {{ site.title }}
             </a>
             <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navMenu">


### PR DESCRIPTION
This ensures that the link from the generated download site is associated
with the url specified in _config.yml (aka `url: "https://slicer.org"`)