### PR TITLE
ci: Fix deployment using ubuntu-20.04 instead of obsolete ubuntu-16.04

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   jekyll:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         branch: [slicer-org, download-slicer-org]

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -31,6 +31,13 @@ jobs:
         enable_cache: true
         custom_opts: ${{ matrix.custom_opts }}
 
+    - name: 'Upload website build'
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.branch }}-website-build
+        path: ./_site
+        retention-days: 1
+
     # See https://github.com/marketplace/actions/github-pages-action
     - name: 🚀 deploy
       if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Each time the sources of the static site organized in the [main](https://github.
 
 ## Preview
 
+### Netlify
+
 | Link | Description |
 |------|-------------|
 | [Deploy Previews for slicer.org][netlify-slicer-org-preview] | Preview of `slicer.org` site automatically associated with pull requests. |
@@ -58,6 +60,11 @@ To learn more about Netlify preview, see [here][netlify-preview-doc].
 [branch-deploy-download-preview]: https://github.com/Slicer/slicer.org/tree/deploy-download-preview
 
 _The netlify deployment has been configured by [@jcfr](https://github.com/jcfr) and since the [free plan](https://www.netlify.com/pricing/) is being used, only one user can update its configuration._
+
+### Website build
+
+The website builds associated with both [slicer-org][branch-slicer-org] and [download-slicer-org][branch-download-slicer-org]
+are also uploaded as GitHub action artifacts.
 
 # Development
 


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources