### PR TITLE
ci: Skip deployment of "deploy-download-preview" if token not available

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -31,9 +31,9 @@ jobs:
     - name: Update status check for deploy-download-preview to pending
       if: |
         matrix.branch == 'deploy-download-preview'
-        && github.ref != 'refs/heads/slicer-org'
-        && github.ref != 'refs/heads/download-slicer-org'
-        && github.ref != 'refs/heads/deploy-download-preview'
+        && github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]'
       uses: ouzi-dev/commit-status-updater@v1.1.2
       with:
         name: 'netlify/deploy-download-preview'
@@ -60,7 +60,10 @@ jobs:
     - name: 🚀 deploy
       if: |
         github.ref == 'refs/heads/main'
-        || matrix.branch == 'deploy-download-preview'
+        || (matrix.branch == 'deploy-download-preview'
+            && github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name == github.repository
+            && github.actor != 'dependabot[bot]')
       uses: peaceiris/actions-gh-pages@v3
       with:
         force_orphan: true
@@ -74,9 +77,9 @@ jobs:
     - name: Update status check for deploy-download-preview
       if: |
         matrix.branch == 'deploy-download-preview'
-        && github.ref != 'refs/heads/slicer-org'
-        && github.ref != 'refs/heads/download-slicer-org'
-        && github.ref != 'refs/heads/deploy-download-preview'
+        && github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]'
       uses: ouzi-dev/commit-status-updater@v1.1.2
       with:
         name: 'netlify/deploy-download-preview'

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Each time the sources of the static site organized in the [main](https://github.
 | Link | Description |
 |------|-------------|
 | [Deploy Previews for slicer.org][netlify-slicer-org-preview] | Preview of `slicer.org` site automatically associated with pull requests. |
-| [Preview for download.slicer.org][netlify-download-slicer-org-preview] | Preview of `download.slicer.org` automatically associated with target branch [deploy-download-preview][branch-deploy-download-preview] |
+| [Preview for download.slicer.org][netlify-download-slicer-org-preview] | Preview of `download.slicer.org` automatically associated with target branch [deploy-download-preview][branch-deploy-download-preview].<br>:warning: Preview is only available for pull request originating from this repository. |
 
 To learn more about Netlify preview, see [here][netlify-preview-doc].
 


### PR DESCRIPTION
Since secret are not available in fork, this commit skips the job if
token is not available.

See https://github.community/t/make-secrets-available-to-builds-of-forks/16166