### PR TITLE
download: Fix rendering of download page within slicer_dowload_server

### DIFF
--- a/_includes/download_table_td.html
+++ b/_includes/download_table_td.html
@@ -15,7 +15,7 @@
   {% capture download_url %}{% raw %}{{{% endraw %}R.{{ operating_system }}.{{ release_type }}.download_url{% raw %}}}{% endraw %}{% endcapture %}
 {% endif %}
 
-{% if release_type == "preview" %}
+{% if release_type == "nightly" %}
   {% assign css_class = "warning" %}
 {% else %}
   {% assign css_class = "" %}

--- a/download.markdown
+++ b/download.markdown
@@ -6,11 +6,11 @@ permalink:
 show_sidebar: false
 animated_navbar: false
 download_mock:
-  stable:
+  release:
     version: 4.2.20420101
     revision: 12345
     built: 2042-01-01
-  preview:
+  nightly:
     version: 7.4.0
     revision: 78910
     built: 2074-01-01
@@ -50,12 +50,12 @@ download_mock:
         <tr>
             <th>Stable Release<br /><span class="table-subheader"><a href="https://www.slicer.org/wiki/Documentation/Nightly/FAQ/General#Where_can_I_download_Slicer.3F">access older releases</a></span></th>
 
-            {% assign release_type = "stable" %}
+            {% assign release_type = "release" %}
 
             {% assign operating_system = "win" %}
             {% include download_table_td.html %}
 
-            {% assign operating_system = "macos" %}
+            {% assign operating_system = "macosx" %}
             {% include download_table_td.html %}
 
             {% assign operating_system = "linux" %}
@@ -65,12 +65,12 @@ download_mock:
         <tr>
             <th>Preview Release</th>
 
-            {% assign release_type = "preview" %}
+            {% assign release_type = "nightly" %}
 
             {% assign operating_system = "win" %}
             {% include download_table_td.html %}
 
-            {% assign operating_system = "macos" %}
+            {% assign operating_system = "macosx" %}
             {% include download_table_td.html %}
 
             {% assign operating_system = "linux" %}


### PR DESCRIPTION
This commit is a follow-up of 769e146 (download: Introduce "download_table_td" template to simplify maintenance) fixing rendering of the download page by using keys matching values associated with `SUPPORTED_OS_CHOICES` and `STABILITY_CHOICES` defined in `slicer_dowload_server`.