### PR TITLE
ci: Fix build-website GitHub Actions workflow updating Ruby from 2.6 to 2.7

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -26,7 +26,7 @@ jobs:
     - name: 💎 setup ruby
       uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1 # v1.144.2
       with:
-        ruby-version: 2.6 # can change this to 2.7 or whatever version you prefer
+        ruby-version: 2.7 # can change this to 2.7 or whatever version you prefer
 
     # See https://github.com/ouzi-dev/commit-status-updater
     - name: Update status check for deploy-download-preview to pending


### PR DESCRIPTION
Related to:
* https://github.com/Slicer/slicer.org/pull/174