### PR TITLE
ci: Ensure netlify worker also uses Ruby 2.7

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,9 @@
   command = "jekyll build"
   publish = "_site/"
 
+[build.environment]
+  RUBY_VERSION = "2.7.2"
+
 # Copied from https://answers.netlify.com/t/jekyll-site-uses-absolute-urls-deploy-previews-navigate-to-main-site/8441/12
 [context.deploy-preview]
   command = "printf \"url: %s\" \"$DEPLOY_PRIME_URL\" > _config_netlify.yml; jekyll build --config _config.yml,_config_netlify.yml"


### PR DESCRIPTION
This pull request is intended to fix:
* https://github.com/Slicer/slicer.org/pull/174

References:
* https://docs.netlify.com/configure-builds/file-based-configuration/#build-settings
* https://docs.netlify.com/configure-builds/available-software-at-build-time/#languages
