### PR TITLE
download: Add support for incomplete releases

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -69,6 +69,14 @@ jobs:
         data_file: _data/template_test_data/download_only_nightly.json
         output_file: _site/download_only_nightly.html
 
+    - name: 'Evaluate download template [incomplete_releases]'
+      if: env.deploy_download_preview == 'true'
+      uses: cuchi/jinja2-action@3fa06acb38601d3caea4c5ce0416e268a8799d71 # v1.2.1
+      with:
+        template: _site/download.html
+        data_file: _data/template_test_data/download_incomplete_releases.json
+        output_file: _site/download_incomplete_releases.html
+
     - name: 'Upload website build'
       if: matrix.branch != 'deploy-download-preview'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -129,6 +137,14 @@ jobs:
         source_url: https://deploy-download-preview--slicer-org.netlify.app/download_only_nightly.html
         imgur_client_id: ${{secrets.SLICER_IMGUR_CLIENT_ID}}
 
+    - name: Capture deploy-download-preview screenshot [incomplete_releases]
+      if: env.deploy_download_preview == 'true'
+      uses: ./.github/actions/screenshot-website-imgur-upload
+      id: capture_deploy_download_preview_incomplete_releases
+      with:
+        source_url: https://deploy-download-preview--slicer-org.netlify.app/download_incomplete_releases.html
+        imgur_client_id: ${{secrets.SLICER_IMGUR_CLIENT_ID}}
+
     # See https://github.com/thollander/actions-comment-pull-request
     - name: Add Pull Request comment including screenshot
       if: env.deploy_download_preview == 'true'
@@ -137,15 +153,19 @@ jobs:
         IMG_URL_0: ${{ steps.capture_deploy_download_preview_release_and_nightly.outputs.imgur_url }}
         IMG_URL_1: ${{ steps.capture_deploy_download_preview_only_release.outputs.imgur_url }}
         IMG_URL_2: ${{ steps.capture_deploy_download_preview_only_nightly.outputs.imgur_url }}
+        IMG_URL_3: ${{ steps.capture_deploy_download_preview_incomplete_releases.outputs.imgur_url }}
         MESSAGE: |
           ### download.slicer.org preview
           _:warning: The download preview is a static website generated using mock data [^1], is temporary and may be updated at anytime [^2]_
           | Screenshot from https://deploy-download-preview--slicer-org.netlify.app/download_release_and_nightly.html | Screenshot from https://deploy-download-preview--slicer-org.netlify.app/download_only_release.html | Screenshot from https://deploy-download-preview--slicer-org.netlify.app/download_only_nightly.html |
           |--|--|--|
           | ![Screenshot]({0}) | ![Screenshot]({1}) | ![Screenshot]({2}) |
+          | Screenshot from https://deploy-download-preview--slicer-org.netlify.app/download_release_and_nightly.html |
+          |--|
+          | ![Screenshot]({3}) |
           [^1]: See [front matter](https://jekyllrb.com/docs/front-matter/) variable `download_mock` associated with https://raw.githubusercontent.com/Slicer/slicer.org/main/download.markdown
           [^2]: Due to limitation of Netlify preventing us from having multiple [deploy previews](https://docs.netlify.com/site-deploys/deploy-previews/) associated with a single pull request and the [impossibility](https://github.community/t/make-secrets-available-to-builds-of-forks/16166) of using repository secret in a workflow associated with a pull-request originating from forks, the `deploy-download-preview` site is only updated for pull request originating from this repository and will be overriden after another pull request is pushed or updated.
       with:
-        message: ${{ format(env.MESSAGE, env.IMG_URL_0, env.IMG_URL_1, env.IMG_URL_2) }}
+        message: ${{ format(env.MESSAGE, env.IMG_URL_0, env.IMG_URL_1, env.IMG_URL_2, env.IMG_URL_3) }}
         GITHUB_TOKEN: ${{ secrets.SLICERBOT_GITHUB_TOKEN }}
 

--- a/_data/template_test_data/download_incomplete_releases.json
+++ b/_data/template_test_data/download_incomplete_releases.json
@@ -1,0 +1,21 @@
+{
+  "download_stats_url": "javascript: alert('download stats');",
+  "R": {
+    "linux": {
+      "release": {
+        "download_url": "javascript: alert('download linux release package');",
+        "version": "5.2.0",
+        "revision": "31322",
+        "build_date_ymd": "2022-11-22"
+      }
+    },
+    "win": {
+      "nightly": {
+        "download_url": "javascript: alert('download win nightly package');",
+        "version": "5.3.0",
+        "revision": "31719",
+        "build_date_ymd": "2023-04-19"
+      }
+    }
+  }
+}

--- a/_includes/download_table_td.html
+++ b/_includes/download_table_td.html
@@ -1,4 +1,5 @@
 
+  {%- capture operating_system_obj %}R.{{ operating_system }}{% endcapture -%}
   {%- capture release_type_obj %}R.{{ operating_system }}.{{ release_type }}{% endcapture -%}
   {%- capture version %}{% raw %}{{{% endraw %}R.{{ operating_system }}.{{ release_type }}.version{% raw %}}}{% endraw %}{% endcapture -%}
   {%- capture revision %}{% raw %}{{{% endraw %}R.{{ operating_system }}.{{ release_type }}.revision{% raw %}}}{% endraw %}{% endcapture -%}
@@ -14,7 +15,7 @@
 
 <!-- _includes/download_table_td.html -->
 <td>
-{% raw %}{% if {% endraw %}{{ release_type_obj }}{% raw %} %}{% endraw %}
+{% raw %}{% if {% endraw %}{{ operating_system_obj }} and {{ release_type_obj }}{% raw %} %}{% endraw %}
     <a href="{{ download_url }}" class="button-download expanded hollow {{ css_class }}">
         <span class="header">{{ version }}</span>
         <br/>revision {{ revision }}


### PR DESCRIPTION
This fixes error like the following reported when including parameter like the following in the URL: `?os=<operating_system>` where `<operating_system>` is any of `(linux, win, macosx)`

Error:

```
Traceback (most recent call last):
  File "/app/entrypoint.py", line 12, in <module>
    context.render_template()
  File "/app/main.py", line 40, in render_template
    file.write(template.render(**self._variables) + '\n')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.11/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/local/lib/python3.11/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 387, in <module>
  File "/usr/local/lib/python3.11/site-packages/jinja2/environment.py", line 471, in getattr
    return getattr(obj, attribute)
           ^^^^^^^^^^^^^^^^^^^^^^^
```