### PR TITLE
Download: Change default tab to "Package Naming Convention" / Fix scrolling on tab click / Impove layout of "Checksums" tab

### DIFF
--- a/.github/actions/screenshot-website-imgur-upload/action.yml
+++ b/.github/actions/screenshot-website-imgur-upload/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     # See https://github.com/swinton/screenshot-website
     - name: Capture screenshot
-      uses: swinton/screenshot-website@5fcf4889015d277ef5e9635eba1fd1c2304a0d3e # v1.x
+      uses: jcfr/screenshot-website@f28f624498a41bcadbae7a09931fdd1a4e4d2617
       id: capture_step
       with:
         source: ${{ inputs.source_url }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,7 +40,7 @@
         </section>
         {% include footer.html %}
     {% endunless %}
-    <script src="{{ site.baseurl }}/assets/js/app.js" type="text/javascript"></script>
+    <script src="{{ site.baseurl }}/assets/js/app.js?v={{ site.time | date:'%s' }}" type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
     <script>anchors.add();</script>
   </body>

--- a/_sass/classes.sass
+++ b/_sass/classes.sass
@@ -394,4 +394,5 @@
         font-size: 1.1rem
         line-height: 1.2
         font-weight: 600
-
+  .tabs
+    scroll-margin-top: $header-height

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         window.location.hash = '#' + tab.id;
       }
-      document.querySelector('div.download').scrollIntoView({behavior: 'smooth'});
+      document.querySelector('div.tabs').scrollIntoView({behavior: 'smooth'});
     })
   });
 

--- a/download.markdown
+++ b/download.markdown
@@ -134,21 +134,25 @@ animated_navbar: false
 
             <p>For each Slicer package listed above, we provide a SHA512 checksum. You can use this checksum to validate that your downloaded file has not been tampered with or corrupted during the download process.</p>
 
-            <p>To verify the integrity of your downloaded package using the checksum, follow these general steps:</p>
+            <details>
+                <summary title="Click to display per-platform instructions for verifying the integrity of your downloaded package">How to verify the integrity of your downloaded package?</summary>
 
-            <ol>
-            <li>Open a terminal window or command prompt.</li>
-            <li>Navigate to the directory where your downloaded package is located.</li>
-            <li>Calculate the checksum of your downloaded package by running the appropriate command for your operating system:
-                <ul>
-                <li>Windows (using PowerShell): <code>Get-FileHash {package filename} -Algorithm SHA512</code></li>
-                <li>macOS: <code>shasum -a 512 {package filename}</code></li>
-                <li>Linux: <code>sha512sum {package filename}</code></li>
-                </ul>
-            </li>
-            <li>Compare the calculated checksum to the expected checksum listed above to ensure they match.</li>
-            </ol>
-            <p>By verifying the checksum of your downloaded package, you can ensure that it has not been tampered with during the download process or otherwise corrupted.</p>
+                <p>To verify the integrity of your downloaded package using the checksum, follow these general steps:</p>
+                <ol>
+                    <li>Open a terminal window or command prompt.</li>
+                    <li>Navigate to the directory where your downloaded package is located.</li>
+                    <li>Calculate the checksum of your downloaded package by running the appropriate command for your operating system:
+                        <ul>
+                        <li>Windows (using PowerShell): <code>Get-FileHash {package filename} -Algorithm SHA512</code></li>
+                        <li>macOS: <code>shasum -a 512 {package filename}</code></li>
+                        <li>Linux: <code>sha512sum {package filename}</code></li>
+                        </ul>
+                    </li>
+                    <li>Compare the calculated checksum to the expected checksum listed above to ensure they match.</li>
+                </ol>
+
+                <p>By verifying the checksum of your downloaded package, you can ensure that it has not been tampered with during the download process or otherwise corrupted.</p>
+            </details>
         </div>
         <div id="tab-package-naming-convention">
             <p class="">Slicer packages are named based on the following naming convention:</p>

--- a/download.markdown
+++ b/download.markdown
@@ -75,13 +75,13 @@ animated_navbar: false
 <div markdown="0">
     <div class="tabs boxed is-centered is-4">
         <ul>
-            <li class="is-active" data-target="tab-checksums" id="checksums">
+            <li data-target="tab-checksums" id="checksums">
                 <a>
                     <span class="icon is-small"><i class="fas fa-shield-alt" aria-hidden="true"></i></span>
                     <span>Checksums</span>
                 </a>
             </li>
-            <li data-target="tab-package-naming-convention" id="package-naming-convention">
+            <li class="is-active" data-target="tab-package-naming-convention" id="package-naming-convention">
                 <a>
                     <span class="icon is-small"><i class="far fa-file-alt" aria-hidden="true"></i></span>
                     <span>Package Naming Convention</span>
@@ -90,7 +90,7 @@ animated_navbar: false
         </ul>
     </div>
     <div id="tab-content" class="is-size-7">
-        <div id="tab-checksums">
+        <div id="tab-checksums" class="is-hidden">
 
             <p>It is a good practice to verify the integrity of your downloaded Slicer package by checking its checksum against the expected values.</p>
 
@@ -150,7 +150,7 @@ animated_navbar: false
             </ol>
             <p>By verifying the checksum of your downloaded package, you can ensure that it has not been tampered with during the download process or otherwise corrupted.</p>
         </div>
-        <div id="tab-package-naming-convention" class="is-hidden">
+        <div id="tab-package-naming-convention">
             <p class="">Slicer packages are named based on the following naming convention:</p>
 
             <p class=""><strong>For Stable Builds:</strong></p>

--- a/download.markdown
+++ b/download.markdown
@@ -70,9 +70,7 @@ animated_navbar: false
             </tbody>
         </table>
     </div>
-</div>
 
-<div markdown="0">
     <div class="tabs boxed is-centered is-4">
         <ul>
             <li data-target="tab-checksums" id="checksums">


### PR DESCRIPTION
* site: Ensure up-to-date version of "app.js" is always fetched
* download: Ensure clicking on a tab scrolls just above the tabs area
* download: Update "Checksums" tab to wrap detailed instruction
* download: Change default tab from "Checksums" to "Package Naming Convention"