### PR TITLE
Switch highlighted social network to LinkedIn

### DIFF
--- a/_data/footer-site-map.yml
+++ b/_data/footer-site-map.yml
@@ -51,9 +51,9 @@ About:
     link: https://www.slicer.org/wiki/Main_Page/SlicerCommunity
   - name: Acknowledgments
     link: https://slicer.readthedocs.io/en/latest/user_guide/about.html#acknowledgments
-  - name: Twitter
-    link: https://twitter.com/3DSlicerApp
-    icon: fab fa-twitter
+  - name: LinkedIn
+    link: https://www.linkedin.com/feed/hashtag/?keywords=3dslicer
+    icon: fab fa-linkedin
   - name: YouTube
     link: https://www.youtube.com/c/3DSlicerChannel
     icon: fab fa-youtube

--- a/commercial-use.markdown
+++ b/commercial-use.markdown
@@ -59,7 +59,7 @@ Many companies prefer not to disclose what software components they use in their
 [allen-icon]: assets/img/logo-allen-institute-for-brain-science.png "Allen Institute for Brain Science"
 [allen-kitware-blog]: https://blog.kitware.com/cell-locator-a-3d-slicer-based-desktop-application-that-manually-aligns-specimens-to-annotated-3d-spaces-developed-for-the-allen-institute-for-brain-science/
 
-<!-- https://twitter.com/PolareanImaging/header_photo -->
+<!-- https://x.com/PolareanImaging/header_photo -->
 [xenoview-icon]: assets/img/logo-polarean.png "Polarean, Inc."
 [xenoview-kitware-blog]: https://www.kitware.com/kitware-supports-development-and-launch-of-fda-cleared-mr-image-processingsoftware-for-lung-ventilation-imaging/
 

--- a/index.markdown
+++ b/index.markdown
@@ -33,9 +33,9 @@ hero_buttons:
     icon: fa fa-comments
     color: logo-yellow
 
-  - text: Twitter
-    link: https://twitter.com/3DSlicerApp
-    icon: fab fa-twitter
+  - text: LinkedIn
+    link: https://www.linkedin.com/feed/hashtag/?keywords=3dslicer
+    icon: fab fa-linkedin
     color: logo-brown
 
 # About ======================================================


### PR DESCRIPTION
The 3DSlicerApp account on X.com (formerly Twitter) has not been active since March 2023. LinkedIn continues to be a focused place for researchers to post about their work in an academic/professional setting unlike X.com that covers a wide spectrum of topics. Therefore LinkedIn may be considered more appropriate for connecting researchers to others in more helpful ways.

Previously discussed in https://discourse.slicer.org/t/social-media-presence-moving-away-from-twitter/30433/8.

![{82569D3A-A005-4A1E-A54C-771718D533E9}](https://github.com/user-attachments/assets/c461530c-35d6-4cd9-bca5-27552af1d535)
