### PR TITLE
Ensure seamless navigation between primary (`slicer.org`) and auxiliary sites (`download.slicer.org`)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,3 +35,4 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 gem 'jekyll-seo-tag'
 gem 'jekyll-target-blank'
 gem 'jekyll_version_plugin'
+gem 'jekyll-spaceship'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.17.0)
     forwardable-extended (2.6.0)
+    gemoji (3.0.1)
     google-protobuf (4.29.2)
       bigdecimal
       rake (>= 13)
@@ -50,6 +51,11 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-spaceship (0.10.2)
+      gemoji (~> 3.0)
+      jekyll (>= 3.6, < 5.0)
+      nokogiri (~> 1.6)
+      rainbow (~> 3.0)
     jekyll-target-blank (2.0.2)
       jekyll (>= 3.0, < 5.0)
       nokogiri (~> 1.10)
@@ -73,6 +79,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
     racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
@@ -95,6 +102,7 @@ DEPENDENCIES
   bulma-clean-theme (= 1.1.0)
   jekyll (~> 4.3)
   jekyll-seo-tag
+  jekyll-spaceship
   jekyll-target-blank
   jekyll_version_plugin
   tzinfo (~> 1.2)

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,10 @@ slicer_download_url: "https://download.slicer.org"
 slicer_download_stats_url: "https://download.slicer.org/download-stats"
 slicer_training_url: "https://www.slicer.org/wiki/Documentation/Nightly/Training"
 
+# Indicates if the configuration is for the primary site (https://slicer.org).
+# Set to "true" for slicer.org and "false" for auxiliary sites like the download site.
+is_primary_site: true
+
 # Cause a build to fail if there is a YAML syntax error in a page's front matter.
 # See https://jekyllrb.com/docs/configuration/options/#build-command-options
 strict_front_matter: true
@@ -61,6 +65,13 @@ plugins:
 jekyll-spaceship:
   processors:
     - element-processor
+  element-processor:
+    css:
+      - 'a.force-internal-link':
+          props:
+            class: ['^(.*) force\-internal\-link$', '\0']   # force-internal-link
+            target: ''                                      # Replace `target` value to ``
+            rel: ''                                         # Replace `rel` value to ``
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_config.yml
+++ b/_config.yml
@@ -56,6 +56,11 @@ plugins:
   - jekyll-seo-tag
   - jekyll-target-blank
   - jekyll_version_plugin
+  - jekyll-spaceship
+
+jekyll-spaceship:
+  processors:
+    - element-processor
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_config_download.yml
+++ b/_config_download.yml
@@ -1,4 +1,10 @@
 
+url: "https://download.slicer.org"
+
+# Indicates if the configuration is for the primary site (https://slicer.org).
+# Set to "true" for slicer.org and "false" for auxiliary sites like the download site.
+is_primary_site: false
+
 # Set the jinja2 template intended to be used in https://github.com/Slicer/slicer_download
 slicer_download_stats_url: "{{download_stats_url}}"
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,14 @@
     <div class="container">
         <div class="navbar-brand">
             <img src="{{ site.logo_image | absolute_url }}" width="35">
-            <a href="{{ '/' | absolute_url }}" class="navbar-item">
+            {% if site.is_primary_site -%}
+                {%- assign primary_site_url = '/' | absolute_url -%}
+                {%- assign force_internal_link_class = '' -%}
+            {%- else -%}
+                {%- assign primary_site_url = "https://slicer.org/" -%}
+                {%- assign force_internal_link_class = 'force-internal-link' -%}
+            {%- endif -%}
+            <a href="{{ primary_site_url }}" class="navbar-item {{ force_internal_link_class }}">
                 {{ site.title }}
             </a>
             <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navMenu">

--- a/_includes/navbar-column.html
+++ b/_includes/navbar-column.html
@@ -5,9 +5,19 @@
         {% for item in items %}
 
         {%- assign item_link = item.link | liquify -%}
+
+        {%- assign item_link_firstchar = item_link | slice: 0, 1 -%}
+        {%- assign force_internal_link_class = '' -%}
+        {% unless site.is_primary_site %}
+            {% if item_link_firstchar == "/" %}
+                {%- assign item_link = "https://slicer.org" | append: item_link -%}
+                {%- assign force_internal_link_class = 'force-internal-link' -%}
+            {% endif %}
+        {% endunless %}
+
         {%- assign item_link_prefix = item_link | slice: 0, 2 -%}
         {% if item_link_prefix != "{{" %}
-        <a href="{{ item_link | absolute_url }}" class="navbar-item {% if item_link == page.url %}is-active{% endif %}">
+        <a href="{{ item_link | absolute_url }}" class="navbar-item {{ force_internal_link_class }} {% if item_link == page.url %}is-active{% endif %}">
         {% else %}
         <a href="{{ item_link }}" class="navbar-item" class="navbar-item {% if item_link == page.url %}is-active{% endif %}">
         {% endif %}

--- a/_includes/navbar-column.html
+++ b/_includes/navbar-column.html
@@ -4,11 +4,12 @@
     <div class="navbar-dropdown">
         {% for item in items %}
 
-        {%- assign item_link_prefix = item.link | liquify | slice: 0, 2 -%}
+        {%- assign item_link = item.link | liquify -%}
+        {%- assign item_link_prefix = item_link | slice: 0, 2 -%}
         {% if item_link_prefix != "{{" %}
-        <a href="{{ item.link | liquify | absolute_url }}" class="navbar-item {% if item.link == page.url %}is-active{% endif %}">
+        <a href="{{ item_link | absolute_url }}" class="navbar-item {% if item_link == page.url %}is-active{% endif %}">
         {% else %}
-        <a href="{{ item.link | liquify }}" class="navbar-item" class="navbar-item {% if item.link == page.url %}is-active{% endif %}">
+        <a href="{{ item_link }}" class="navbar-item" class="navbar-item {% if item_link == page.url %}is-active{% endif %}">
         {% endif %}
             {% if item.icon %}
             <i class="{{ item.icon }}"></i>&nbsp;

--- a/_includes/sitemap-column.html
+++ b/_includes/sitemap-column.html
@@ -3,11 +3,12 @@
     <h4>{{ title }}</h4>
     {% for item in items %}
     <div>
-        {%- assign item_link_prefix = item.link | liquify | slice: 0, 2 -%}
+        {%- assign item_link = item.link | liquify -%}
+        {%- assign item_link_prefix = item_link | slice: 0, 2 -%}
         {% if item_link_prefix != "{{" %}
-        <a href="{{ item.link | liquify | absolute_url }}" class="sitemap-item">
+        <a href="{{ item_link | absolute_url }}" class="sitemap-item">
         {% else %}
-        <a href="{{ item.link | liquify }}" class="sitemap-item">
+        <a href="{{ item_link }}" class="sitemap-item">
         {% endif %}
             {% if item.icon %}
             <i class="{{ item.icon }}"></i>

--- a/_includes/sitemap-column.html
+++ b/_includes/sitemap-column.html
@@ -4,9 +4,19 @@
     {% for item in items %}
     <div>
         {%- assign item_link = item.link | liquify -%}
+
+        {%- assign item_link_firstchar = item_link | slice: 0, 1 -%}
+        {%- assign force_internal_link_class = '' -%}
+        {% unless site.is_primary_site %}
+            {% if item_link_firstchar == "/" %}
+                {%- assign item_link = "https://slicer.org" | append: item_link -%}
+                {%- assign force_internal_link_class = 'force-internal-link' -%}
+            {% endif %}
+        {% endunless %}
+
         {%- assign item_link_prefix = item_link | slice: 0, 2 -%}
         {% if item_link_prefix != "{{" %}
-        <a href="{{ item_link | absolute_url }}" class="sitemap-item">
+        <a href="{{ item_link | absolute_url }}" class="sitemap-item {{ force_internal_link_class }}">
         {% else %}
         <a href="{{ item_link }}" class="sitemap-item">
         {% endif %}


### PR DESCRIPTION
This pull request addresses issues where navigating between internal pages and those hosted on an auxiliary site would open additional tabs. The following key changes have been introduced:

1. **Setting the top-level `url` configuration** to match the auxiliary site’s actual URL. This ensures:
   - Links to the download site are treated as internal, preventing unnecessary new tab openings.
   - Various `<meta>` elements, as well as generated files such as `browserconfig.xml`, `robots.txt`, and `sitemap.xml`, correctly reference `https://download.slicer.org` instead of `https://slicer.org`.

2. **Introducing the `is_primary_site` config variable** to differentiate between the primary site (`slicer.org`) and auxiliary sites (e.g., `download.slicer.org`). This variable is now used in the `header`, `navbar-column`, and `sitemap-column` includes to conditionally generate links.

3. **Enhancing link post-processing** via the `jekyll-spaceship` plugin to handle links with the `force-internal-link` class. This class is conditionally applied based on the `is_primary_site` setting. The adjustment is necessary to counteract the `jekyll-target-blank` plugin, which enforces opening external links in a new window by default.