### PR TITLE
fix: Use Slicer fork of jinja2-action to fix Poetry 2.0 breaking change

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -94,7 +94,7 @@ jobs:
 
     - name: 'Evaluate download template [release_and_nightly]'
       if: env.deploy_download_preview == 'true'
-      uses: cuchi/jinja2-action@6d31ec73a23fdd391e21e3efce8a91a87762980d # v1.2.2
+      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # slicer-2023-11-09-2ea7da6
       with:
         template: _site/download.html
         data_file: _data/template_test_data/download_release_and_nightly.json
@@ -102,7 +102,7 @@ jobs:
 
     - name: 'Evaluate download template [only_release]'
       if: env.deploy_download_preview == 'true'
-      uses: cuchi/jinja2-action@6d31ec73a23fdd391e21e3efce8a91a87762980d # v1.2.2
+      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # slicer-2023-11-09-2ea7da6
       with:
         template: _site/download.html
         data_file: _data/template_test_data/download_only_release.json
@@ -110,7 +110,7 @@ jobs:
 
     - name: 'Evaluate download template [only_nightly]'
       if: env.deploy_download_preview == 'true'
-      uses: cuchi/jinja2-action@6d31ec73a23fdd391e21e3efce8a91a87762980d # v1.2.2
+      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # slicer-2023-11-09-2ea7da6
       with:
         template: _site/download.html
         data_file: _data/template_test_data/download_only_nightly.json
@@ -118,7 +118,7 @@ jobs:
 
     - name: 'Evaluate download template [incomplete_releases]'
       if: env.deploy_download_preview == 'true'
-      uses: cuchi/jinja2-action@6d31ec73a23fdd391e21e3efce8a91a87762980d # v1.2.2
+      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # slicer-2023-11-09-2ea7da6
       with:
         template: _site/download.html
         data_file: _data/template_test_data/download_incomplete_releases.json


### PR DESCRIPTION
As of 2025-01-08, the latest version of `cuchi/jinja2-action` broke due to a breaking change introduced in poetry 2.0:
* https://github.com/cuchi/jinja2-action/pull/21
* https://github.com/cuchi/jinja2-action/issues/22

This fork was created to provide the fix originally contributed by @OlivierCloudar, ensuring it is associated with a GitHub organization rather than an individual user account.
See https://github.com/Slicer/jinja2-action