### PR TITLE
fix: Always handle download link as internal

### DIFF
--- a/_data/footer-site-map.yml
+++ b/_data/footer-site-map.yml
@@ -5,6 +5,7 @@ Application:
     icon: fa fa-rocket
   - name: Download
     link: "{{ site.slicer_download_url }}"
+    link_class: force-internal-link
     icon: fa fa-download
 
 Support:

--- a/_includes/hero-main.html
+++ b/_includes/hero-main.html
@@ -11,7 +11,7 @@
                     {% if page.hero_buttons %}
                     <div class="buttons is-left">
                       {% for button in page.hero_buttons %}
-                          <a href="{{ button.link | liquify }}" onclick="this.blur();" class="button hero-button is-medium {{ button.color }}">
+                          <a href="{{ button.link | liquify }}" onclick="this.blur();" class="button hero-button is-medium {{ button.color }} {{ button.link_class }}">
                             <span class="icon is-small">
                                 <i class="{{ button.icon }}"></i>
                             </span>

--- a/_includes/navbar-column.html
+++ b/_includes/navbar-column.html
@@ -5,19 +5,19 @@
         {% for item in items %}
 
         {%- assign item_link = item.link | liquify -%}
+        {%- assign item_link_class = item.link_class -%}
 
         {%- assign item_link_firstchar = item_link | slice: 0, 1 -%}
-        {%- assign force_internal_link_class = '' -%}
         {% unless site.is_primary_site %}
             {% if item_link_firstchar == "/" %}
                 {%- assign item_link = "https://slicer.org" | append: item_link -%}
-                {%- assign force_internal_link_class = 'force-internal-link' -%}
+                {%- assign item_link_class = 'force-internal-link' -%}
             {% endif %}
         {% endunless %}
 
         {%- assign item_link_prefix = item_link | slice: 0, 2 -%}
         {% if item_link_prefix != "{{" %}
-        <a href="{{ item_link | absolute_url }}" class="navbar-item {{ force_internal_link_class }} {% if item_link == page.url %}is-active{% endif %}">
+        <a href="{{ item_link | absolute_url }}" class="navbar-item {{ item_link_class }} {% if item_link == page.url %}is-active{% endif %}">
         {% else %}
         <a href="{{ item_link }}" class="navbar-item" class="navbar-item {% if item_link == page.url %}is-active{% endif %}">
         {% endif %}

--- a/_includes/sitemap-column.html
+++ b/_includes/sitemap-column.html
@@ -4,19 +4,19 @@
     {% for item in items %}
     <div>
         {%- assign item_link = item.link | liquify -%}
+        {%- assign item_link_class = item.link_class -%}
 
         {%- assign item_link_firstchar = item_link | slice: 0, 1 -%}
-        {%- assign force_internal_link_class = '' -%}
         {% unless site.is_primary_site %}
             {% if item_link_firstchar == "/" %}
                 {%- assign item_link = "https://slicer.org" | append: item_link -%}
-                {%- assign force_internal_link_class = 'force-internal-link' -%}
+                {%- assign item_link_class = 'force-internal-link' -%}
             {% endif %}
         {% endunless %}
 
         {%- assign item_link_prefix = item_link | slice: 0, 2 -%}
         {% if item_link_prefix != "{{" %}
-        <a href="{{ item_link | absolute_url }}" class="sitemap-item {{ force_internal_link_class }}">
+        <a href="{{ item_link | absolute_url }}" class="sitemap-item {{ item_link_class }}">
         {% else %}
         <a href="{{ item_link }}" class="sitemap-item">
         {% endif %}

--- a/index.markdown
+++ b/index.markdown
@@ -10,6 +10,7 @@ subtitle: 3D Slicer is a <span class="highlight-text"><b>free</b></span>, <span 
 hero_buttons:
   - text: Download
     link: "{{ site.slicer_download_url }}"
+    link_class: force-internal-link
     icon: fa fa-download
     color: logo-blue
 


### PR DESCRIPTION
Ensure seamless navigation from primary (`slicer.org`) to auxiliary (`download.slicer.org`) site.

Set `link_class` to handle links with the `force-internal-link` class, preventing auxiliary site links from opening in a new tab.

Modify `footer-site-map.yml` and hero buttons to support `link_class`.