### PR TITLE
ci: Attempt to fix dependabot failure to resolve "Slicer/jinja2-action" version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     commit-message:
       # Prefix all commit messages with "ci: "
       prefix: "ci"
+    ignore:
+      # Ignore "Slicer/jinja2-action" expected to be manually updated
+      - dependency-name: "Slicer/jinja2-action"


### PR DESCRIPTION
This is expected to address the following error introduced in 5abe070 ("fix: Use Slicer fork of jinja2-action to fix Poetry 2.0 breaking change", 2025-01-08)

> Dependabot could not find a dependency version.
> Dependabot could not resolve semantic versions for dependencies : Slicer/jinja2-action