### PR TITLE
ci: Another attempt to fix dependabot failure to resolve "Slicer/jinja2-action" version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,3 @@ updates:
     commit-message:
       # Prefix all commit messages with "ci: "
       prefix: "ci"
-    ignore:
-      # Ignore "Slicer/jinja2-action" expected to be manually updated
-      - dependency-name: "Slicer/jinja2-action"

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -94,7 +94,7 @@ jobs:
 
     - name: 'Evaluate download template [release_and_nightly]'
       if: env.deploy_download_preview == 'true'
-      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # slicer-2023-11-09-2ea7da6
+      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # see branch "slicer-2023-11-09-2ea7da6"
       with:
         template: _site/download.html
         data_file: _data/template_test_data/download_release_and_nightly.json
@@ -102,7 +102,7 @@ jobs:
 
     - name: 'Evaluate download template [only_release]'
       if: env.deploy_download_preview == 'true'
-      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # slicer-2023-11-09-2ea7da6
+      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # see branch "slicer-2023-11-09-2ea7da6"
       with:
         template: _site/download.html
         data_file: _data/template_test_data/download_only_release.json
@@ -110,7 +110,7 @@ jobs:
 
     - name: 'Evaluate download template [only_nightly]'
       if: env.deploy_download_preview == 'true'
-      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # slicer-2023-11-09-2ea7da6
+      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # see branch "slicer-2023-11-09-2ea7da6"
       with:
         template: _site/download.html
         data_file: _data/template_test_data/download_only_nightly.json
@@ -118,7 +118,7 @@ jobs:
 
     - name: 'Evaluate download template [incomplete_releases]'
       if: env.deploy_download_preview == 'true'
-      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # slicer-2023-11-09-2ea7da6
+      uses: Slicer/jinja2-action@d94dd73f31971ae95cb4cfee57236618c65ccb7f # see branch "slicer-2023-11-09-2ea7da6"
       with:
         template: _site/download.html
         data_file: _data/template_test_data/download_incomplete_releases.json


### PR DESCRIPTION
This is expected to address the following error introduced in 5abe070 ("fix: Use Slicer fork of jinja2-action to fix Poetry 2.0 breaking change", 2025-01-08)

> Dependabot could not find a dependency version.
> Dependabot could not resolve semantic versions for dependencies : Slicer/jinja2-action

Instead of listing "Slicer/jinja2-action" as dependency to ignore, this pull request reverts changes originally introduced in https://github.com/Slicer/slicer.org/pull/298 and instead changes the comment to include multiple strings and not only one version specifier.

For reference, see https://github.com/dependabot/dependabot-core/blob/e45d543f4556fa040f0b7add3b1184c9b15074fe/github_actions/lib/dependabot/github_actions/file_updater.rb#L88-L94
