### PR TITLE
fix: Allow page subtitle to standout adding top margin

### DIFF
--- a/_sass/classes.sass
+++ b/_sass/classes.sass
@@ -18,6 +18,9 @@
 .title, .subtitle
   margin-bottom: 1.5rem
 
+.subtitle
+  margin-top: 1.5rem
+
 .description
   margin-bottom: 25px
   a:hover


### PR DESCRIPTION
| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/1ce16723-d60e-4599-99ba-29ee56a05b16) | ![image](https://github.com/user-attachments/assets/39e9c176-5153-4f06-a600-af1e3c8a4b68) |
