### PR TITLE
fix: Allow customization of revision link in footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,9 @@ slicer_download_url: "https://download.slicer.org"
 slicer_download_stats_url: "https://download.slicer.org/download-stats"
 slicer_training_url: "https://www.slicer.org/wiki/Documentation/Nightly/Training"
 
+# Specify the name of the GitHub repository hosting the sources of the generated site.
+github_repository: Slicer/slicer.org
+
 # Specifies whether the configuration is for the primary site (https://slicer.org).
 # Set to "true" for slicer.org and "false" for auxiliary sites.
 #

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,14 @@
       <div class="content is-small has-text-centered">
           Content of this site is Copyright {{ site.time | date: "%Y" }} BWH and 3D Slicer contributors, unless otherwise noted.
           <br>For questions about the use of this site's content, please see <a href="https://www.slicer.org/wiki/Contact">Contact</a>.
-          <br>Last update {{ site.time | date: "%Y-%m-%d" }}. Revision <a id="revision" href="https://github.com/Slicer/slicer.org/commit/{% project_version commit short %}">{% project_version commit short %}</a>.
+          {%- if site.github_short_sha and site.github_short_sha != "" and site.github_short_sha != nil -%}
+            {%- assign github_short_sha = site.github_short_sha -%}
+          {%- else -%}
+            {%- capture github_short_sha -%}
+            {%- project_version commit short -%}
+            {%- endcapture -%}
+          {%- endif -%}
+          <br>Last update {{ site.time | date: "%Y-%m-%d" }}. Revision <a id="revision" href="https://github.com/{{ site.github_repository }}/commit/{{ github_short_sha }}">{{ github_short_sha }}</a>.
       </div>
   </div>
 </footer>


### PR DESCRIPTION
Introduce two new site variables for improved flexibility in rendering the revision link:
- `github_repository`: Specifies the GitHub repository hosting the site sources (always set).
- `github_short_sha`: Optionally set to a predefined value; if not initialized, it defaults to the value retrieved using the `project_version` Jekyll plugin.

This ensures that the revision link in the footer correctly references the intended repository and commit, even when `github_short_sha` is externally provided.