### PR TITLE
feat: Use updated URL for training site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ logo_image: /assets/img/3D-Slicer-Mark.svg
 # favicons are directly specified in _includes/head.html
 slicer_download_url: "https://download.slicer.org"
 slicer_download_stats_url: "https://download.slicer.org/download-stats"
-slicer_training_url: "https://www.slicer.org/wiki/Documentation/Nightly/Training"
+slicer_training_url: "https://training.slicer.org"
 
 # Specify the name of the GitHub repository hosting the sources of the generated site.
 github_repository: Slicer/slicer.org

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,3 +1,4 @@
 url: http://localhost:4000
 slicer_download_url: http://localhost:4000/download.html
+slicer_training_url: http://localhost:4000/training.html
 

--- a/_data/footer-site-map.yml
+++ b/_data/footer-site-map.yml
@@ -12,6 +12,7 @@ Support:
   items:
   - name: Training
     link: "{{ site.slicer_training_url }}"
+    link_class: force-internal-link
     icon: fa fa-graduation-cap
   - name: Documentation
     link: https://slicer.readthedocs.io

--- a/index.markdown
+++ b/index.markdown
@@ -26,6 +26,7 @@ hero_buttons:
 
   - text: Training
     link: "{{ site.slicer_training_url }}"
+    link_class: force-internal-link
     icon: fa fa-graduation-cap
     color: logo-orange
 


### PR DESCRIPTION
Update from https://www.slicer.org/wiki/Documentation/Nightly/Training to https://training.slicer.org