### PR TITLE
ci: Fix deployment using ubuntu-24.04 instead of obsolete ubuntu-20.04

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   jekyll:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         branch: [slicer-org, download-slicer-org, download-maintenance-slicer-org, deploy-download-preview, deploy-download-maintenance-preview]


### PR DESCRIPTION
Ubuntu 20 image is retired as of April 15th, 2025. https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

This is a follow-up to https://github.com/Slicer/slicer.org/commit/6a7e239f5602d4f0f0df0eda0510bd0766cbcc0d when the Ubuntu image was bumped from 16.04 to 20.04.