### PR TITLE
download: Add "browse extensions" link for each Slicer version

### DIFF
--- a/_data/template_test_data/download_incomplete_releases.json
+++ b/_data/template_test_data/download_incomplete_releases.json
@@ -4,6 +4,7 @@
     "linux": {
       "release": {
         "download_url": "javascript: alert('download linux release package');",
+        "extensions_browse_url": "javascript: alert('browse linux release extensions');",
         "version": "5.2.0",
         "revision": "31322",
         "build_date_ymd": "2022-11-22",
@@ -13,6 +14,7 @@
     "win": {
       "nightly": {
         "download_url": "javascript: alert('download win nightly package');",
+        "extensions_browse_url": "javascript: alert('browse win nightly extensions');",
         "version": "5.3.0",
         "revision": "31719",
         "build_date_ymd": "2023-04-19",

--- a/_data/template_test_data/download_only_nightly.json
+++ b/_data/template_test_data/download_only_nightly.json
@@ -4,6 +4,7 @@
     "linux": {
       "nightly": {
         "download_url": "javascript: alert('download linux nightly package');",
+        "extensions_browse_url": "javascript: alert('browse linux nightly extensions');",
         "version": "5.3.0",
         "revision": "31717",
         "build_date_ymd": "2023-04-17",
@@ -13,6 +14,7 @@
     "macosx": {
       "nightly": {
         "download_url": "javascript: alert('download macosx nightly package');",
+        "extensions_browse_url": "javascript: alert('browse macosx nightly extensions');",
         "version": "5.3.0",
         "revision": "31718",
         "build_date_ymd": "2023-04-18",
@@ -22,6 +24,7 @@
     "win": {
       "nightly": {
         "download_url": "javascript: alert('download win nightly package');",
+        "extensions_browse_url": "javascript: alert('browse win nightly extensions');",
         "version": "5.3.0",
         "revision": "31719",
         "build_date_ymd": "2023-04-19",

--- a/_data/template_test_data/download_only_release.json
+++ b/_data/template_test_data/download_only_release.json
@@ -4,6 +4,7 @@
     "linux": {
       "release": {
         "download_url": "javascript: alert('download linux release package');",
+        "extensions_browse_url": "javascript: alert('browse linux release extensions');",
         "version": "5.2.0",
         "revision": "31314",
         "build_date_ymd": "2022-11-22",
@@ -13,6 +14,7 @@
     "macosx": {
       "release": {
         "download_url": "javascript: alert('download macosx release package');",
+        "extensions_browse_url": "javascript: alert('browse macosx release extensions');",
         "version": "5.2.0",
         "revision": "31314",
         "build_date_ymd": "2022-11-23",
@@ -22,6 +24,7 @@
     "win": {
       "release": {
         "download_url": "javascript: alert('download win release package');",
+        "extensions_browse_url": "javascript: alert('browse win release extensions');",
         "version": "5.2.0",
         "revision": "31314",
         "build_date_ymd": "2022-11-24",

--- a/_data/template_test_data/download_release_and_nightly.json
+++ b/_data/template_test_data/download_release_and_nightly.json
@@ -4,6 +4,7 @@
     "linux": {
       "release": {
         "download_url": "javascript: alert('download linux release package');",
+        "extensions_browse_url": "javascript: alert('browse linux release extensions');",
         "version": "5.2.0",
         "revision": "31322",
         "build_date_ymd": "2022-11-22",
@@ -11,6 +12,7 @@
       },
       "nightly": {
         "download_url": "javascript: alert('download linux nightly package');",
+        "extensions_browse_url": "javascript: alert('browse linux nightly extensions');",
         "version": "5.3.0",
         "revision": "31717",
         "build_date_ymd": "2023-04-17",
@@ -20,6 +22,7 @@
     "macosx": {
       "release": {
         "download_url": "javascript: alert('download macosx release package');",
+        "extensions_browse_url": "javascript: alert('browse macosx release extensions');",
         "version": "5.2.0",
         "revision": "31323",
         "build_date_ymd": "2022-11-23",
@@ -27,6 +30,7 @@
       },
       "nightly": {
         "download_url": "javascript: alert('download macosx nightly package');",
+        "extensions_browse_url": "javascript: alert('browse macosx nightly extensions');",
         "version": "5.3.0",
         "revision": "31718",
         "build_date_ymd": "2023-04-18",
@@ -36,6 +40,7 @@
     "win": {
       "release": {
         "download_url": "javascript: alert('download win release package');",
+        "extensions_browse_url": "javascript: alert('browse win release extensions');",
         "version": "5.2.0",
         "revision": "31324",
         "build_date_ymd": "2022-11-24",
@@ -43,6 +48,7 @@
       },
       "nightly": {
         "download_url": "javascript: alert('download win nightly package');",
+        "extensions_browse_url": "javascript: alert('browse win nightly extensions');",
         "version": "5.3.0",
         "revision": "31719",
         "build_date_ymd": "2023-04-19",

--- a/_includes/download_table_td.html
+++ b/_includes/download_table_td.html
@@ -6,6 +6,7 @@
   {%- capture build_date_ymd %}{% raw %}{{{% endraw %}R.{{ operating_system }}.{{ release_type }}.build_date_ymd{% raw %}}}{% endraw %}{% endcapture -%}
 
   {%- capture download_url %}{% raw %}{{{% endraw %}R.{{ operating_system }}.{{ release_type }}.download_url{% raw %}}}{% endraw %}{% endcapture -%}
+  {%- capture extensions_browse_url %}{% raw %}{{{% endraw %}R.{{ operating_system }}.{{ release_type }}.extensions_browse_url{% raw %}}}{% endraw %}{% endcapture -%}
 
 {%- if release_type == "nightly" -%}
   {%- assign css_class = "warning" -%}
@@ -16,12 +17,15 @@
 <!-- _includes/download_table_td.html -->
 <td>
 {% raw %}{% if {% endraw %}{{ operating_system_obj }} and {{ release_type_obj }}{% raw %} %}{% endraw %}
+  <div class="cell-download">
     <a href="{{ download_url }}" class="button-download expanded hollow {{ css_class }}">
         <span class="header">{{ version }}</span>
         <br/>revision {{ revision }}
         <br/>built {{ build_date_ymd }}
         <br/><i class="fas fa-download"></i>
     </a>
+    <a class="table-subheader browse-extension {{ css_class }}" href="{{ extensions_browse_url }}">browse extensions</a>
+  </div>
 {% raw %}{% else %}{% endraw %}
     <i>Not available</i>
 {% raw %}{% endif %}{% endraw %}

--- a/_sass/classes.sass
+++ b/_sass/classes.sass
@@ -390,6 +390,11 @@
         height: 75px
     th, td
       border: none
+    td
+      div.cell-download
+        border: 1px solid #e1e1e1
+        padding: 0.85em 1em
+        font-size: 0.8rem
     .button-download
       display: inline-block
       text-align: center
@@ -401,7 +406,7 @@
       border: 1px solid transparent
       border-radius: 0
       padding: 0.85em 1em
-      margin: 0 1rem 1rem 0
+      margin: 0 0.5rem 0.5rem 0
       font-size: 0.8rem
       background: $stable-download-color
       color: #fff
@@ -438,5 +443,15 @@
         font-size: 1.1rem
         line-height: 1.2
         font-weight: 600
+    .browse-extension
+      color: $stable-download-color
+      transition: all 0.25s ease-out
+      &:hover, &:focus
+        color: $stable-download-hover-color
+        text-decoration: none
+      &.warning
+        color: $preview-download-color
+        &:hover, &:focus
+          color: $preview-download-hover-color
   .tabs
     scroll-margin-top: $header-height


### PR DESCRIPTION
Related `slicer_download` update: https://github.com/Slicer/slicer_download/commit/2a29258e9199cb3a8a1f07f020c1a39559f4f55d (`slicer_download_server: Set "extensions_browse_url" metadata`)

---

|Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/b512eb3c-52a8-4606-84c9-9c6a2803fa53) |  ![image](https://github.com/user-attachments/assets/3e214443-22e6-4d18-9b77-18135d7808f6) |

