### PR TITLE
Add combobox selector for previous version

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,6 +64,71 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   });
 
+  // Older stable release picker (on the download page)
+  const releaseVersionSelect = document.getElementById('older-release-version');
+  if (releaseVersionSelect) {
+    const releaseOsSelect = document.getElementById('older-release-os');
+    const releaseDownloadButton = document.getElementById('older-release-download');
+
+    // Pre-select the operating system based on the visitor's platform
+    const platform = (navigator.userAgent + ' ' + (navigator.platform || '')).toLowerCase();
+    if (platform.indexOf('win') !== -1) {
+      releaseOsSelect.value = 'win';
+    } else if (platform.indexOf('mac') !== -1) {
+      releaseOsSelect.value = 'macosx';
+    } else {
+      releaseOsSelect.value = 'linux';
+    }
+
+    // Compare two version strings (e.g. "5.12.0", "4.11.20210226") numerically, descending
+    const compareVersionsDesc = (a, b) => {
+      const pa = a.split(/[.-]/).map(Number);
+      const pb = b.split(/[.-]/).map(Number);
+      for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+        const na = pa[i] || 0;
+        const nb = pb[i] || 0;
+        if (na !== nb) {
+          return nb - na;
+        }
+      }
+      return 0;
+    };
+
+    // Populate the version combobox from the Slicer packages API
+    fetch('https://slicer-packages.kitware.com/api/v1/app/5f4474d0e1d8c75dfc705482/release')
+      .then(response => response.json())
+      .then(releases => {
+        const versions = releases
+          .map(release => release.name)
+          .filter(name => name)
+          .sort(compareVersionsDesc)
+          // Drop the latest stable release; it is already offered in the table above
+          .slice(1);
+        releaseVersionSelect.innerHTML = '';
+        versions.forEach(version => {
+          const option = document.createElement('option');
+          option.value = version;
+          option.textContent = 'Slicer ' + version;
+          releaseVersionSelect.appendChild(option);
+        });
+      })
+      .catch(() => {
+        releaseVersionSelect.innerHTML = '<option value="">Could not load versions</option>';
+      });
+
+    // Navigate to the direct download URL for the selected version and OS
+    releaseDownloadButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      const version = releaseVersionSelect.value;
+      const os = releaseOsSelect.value;
+      if (!version) {
+        return;
+      }
+      window.location.href = 'https://download.slicer.org/download?version=' +
+        encodeURIComponent(version) + '&os=' + encodeURIComponent(os) + '&stability=release';
+    });
+  }
+
   // Select tab with an ID matching the current URL's fragment
   $('div.tabs li:target').click();
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -94,27 +94,46 @@ document.addEventListener('DOMContentLoaded', () => {
       return 0;
     };
 
-    // Populate the version combobox from the Slicer packages API
-    fetch('https://slicer-packages.kitware.com/api/v1/app/5f4474d0e1d8c75dfc705482/release')
-      .then(response => response.json())
-      .then(releases => {
-        const versions = releases
-          .map(release => release.name)
-          .filter(name => name)
-          .sort(compareVersionsDesc)
-          // Drop the latest stable release; it is already offered in the table above
-          .slice(1);
-        releaseVersionSelect.innerHTML = '';
-        versions.forEach(version => {
-          const option = document.createElement('option');
-          option.value = version;
-          option.textContent = 'Slicer ' + version;
-          releaseVersionSelect.appendChild(option);
+    // Populate the version combobox from the Slicer packages API.
+    // Deferred until the "Access Older Releases" tab is first opened, so the
+    // request is not made on every visit to the download page.
+    let versionsRequested = false;
+    const populateReleaseVersions = () => {
+      if (versionsRequested) {
+        return;
+      }
+      versionsRequested = true;
+      fetch('https://slicer-packages.kitware.com/api/v1/app/5f4474d0e1d8c75dfc705482/release')
+        .then(response => response.json())
+        .then(releases => {
+          const versions = releases
+            .map(release => release.name)
+            .filter(name => name)
+            .sort(compareVersionsDesc)
+            // Drop the latest stable release; it is already offered in the table above
+            .slice(1);
+          releaseVersionSelect.innerHTML = '';
+          versions.forEach(version => {
+            const option = document.createElement('option');
+            option.value = version;
+            option.textContent = 'Slicer ' + version;
+            releaseVersionSelect.appendChild(option);
+          });
+        })
+        .catch(() => {
+          // Allow a later tab visit to retry the request
+          versionsRequested = false;
+          releaseVersionSelect.innerHTML = '<option value="">Could not load versions</option>';
         });
-      })
-      .catch(() => {
-        releaseVersionSelect.innerHTML = '<option value="">Could not load versions</option>';
-      });
+    };
+
+    // Fetch the versions the first time the older-releases tab is opened.
+    // Clicking the tab fires this listener, including when the page auto-selects
+    // the tab from the URL fragment (#access-older-releases) further below.
+    const olderReleasesTab = document.getElementById('access-older-releases');
+    if (olderReleasesTab) {
+      olderReleasesTab.addEventListener('click', populateReleaseVersions);
+    }
 
     // Navigate to the direct download URL for the selected version and OS
     releaseDownloadButton.addEventListener('click', (event) => {

--- a/download.markdown
+++ b/download.markdown
@@ -218,11 +218,32 @@ animated_navbar: false
             </table>
         </div>
         <div id="tab-access-older-releases"  class="is-hidden">
-            <p class=""><strong>Get older Slicer Stable Releases:</strong></p>
+            <p class=""><strong>Download an older Slicer Stable Release:</strong></p>
 
-            <p class="">You can add <code>version</code> parameter to the download page address. For example, use this link to get latest Slicer-5.8 release (i.e., Slicer-5.8.1): <a href="http://download.slicer.org/?version=5.8">http://download.slicer.org/?version=5.8</a>.</p>
-
-            <p class="">To get a direct download URL, set <code>version</code> to the desired version (such as <code>5.8</code>), <code>os</code> (<code>win</code>, <code>macosx</code>, or <code>linux</code>), and <code>stability=release</code>. For example: <a href="https://download.slicer.org/download?version=5.8&os=win&stability=release">https://download.slicer.org/download?version=5.8&os=win&stability=release</a></p>
+            <div class="field is-grouped older-release-picker mb-5">
+                <div class="control">
+                    <div class="select is-small">
+                        <select id="older-release-version" aria-label="Slicer version">
+                            <option value="">Loading versions…</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="control">
+                    <div class="select is-small">
+                        <select id="older-release-os" aria-label="Operating system">
+                            <option value="win">Windows</option>
+                            <option value="macosx">macOS</option>
+                            <option value="linux">Linux</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="control">
+                    <a id="older-release-download" class="button is-small" href="#">
+                        <span class="icon is-small"><i class="fas fa-download"></i></span>
+                        <span>Download</span>
+                    </a>
+                </div>
+            </div>
 
             <p class=""><strong>Get older Slicer Preview Releases:</strong></p>
 

--- a/download.markdown
+++ b/download.markdown
@@ -218,7 +218,7 @@ animated_navbar: false
             </table>
         </div>
         <div id="tab-access-older-releases"  class="is-hidden">
-            <p class=""><strong>Download an older Slicer Stable Release:</strong></p>
+            <p class=""><strong>Download an older and unsupported Slicer Stable Release:</strong></p>
 
             <div class="field is-grouped older-release-picker mb-5">
                 <div class="control">


### PR DESCRIPTION
Add combobox to select previous stable release and combobox to select OS with a download button next to them

<img width="1835" height="879" alt="Screenshot from 2026-06-30 16-46-24" src="https://github.com/user-attachments/assets/7d5ac8d3-8ae2-491c-8635-1b8c2e9e44d8" />
