### PR TITLE
Avoid local network access prompt for newer versions of Chrome

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -103,7 +103,10 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       versionsRequested = true;
-      fetch('https://slicer-packages.kitware.com/api/v1/app/5f4474d0e1d8c75dfc705482/release')
+      // Declare the target as a public address so Chrome does not show the
+      // "Access other devices on your local network" (Local Network Access)
+      // permission prompt for this cross-origin request.
+      fetch('https://slicer-packages.kitware.com/api/v1/app/5f4474d0e1d8c75dfc705482/release', { targetAddressSpace: 'public' })
         .then(response => response.json())
         .then(releases => {
           const versions = releases


### PR DESCRIPTION
# Fix: Suppress "Access other devices on your local network" dialog

## Problem
On `download.slicer.org`, opening the "Access Older Releases" tab triggered
Chrome's **Local Network Access** permission dialog:

> download.slicer.org wants to — Access other devices on your local network

This happened because the older-release version list is loaded via `fetch()`.
When Chrome can't determine a request's target address space upfront, it
speculatively shows the local-network permission prompt.

## Fix
Declare the request target as a public address using the `targetAddressSpace`
fetch option in [`assets/js/app.js`](assets/js/app.js#L106):

```js
fetch('https://slicer-packages.kitware.com/api/v1/app/5f4474d0e1d8c75dfc705482/release',
      { targetAddressSpace: 'public' })
```

## Why it works
- `targetAddressSpace: 'public'` tells the browser the request targets a public
  host, so Chrome skips the local-network check and never shows the prompt.
- The option is safely ignored by browsers that don't support it (unknown fetch
  init keys are no-ops), so no fallback is needed.
- Since the target (`slicer-packages.kitware.com`) is genuinely public, there is
  no behavior change beyond suppressing the dialog.
