### PR TITLE
Generate stable release list at build time instead of client-side fetch

### DIFF
--- a/_plugins/slicer_stable_releases.rb
+++ b/_plugins/slicer_stable_releases.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "jekyll"
+require "open-uri"
+require "json"
+require "uri"
+
+# Fetches the list of published 3D Slicer stable releases from the Slicer
+# packages API once, at build time, and exposes it as
+# `site.data["slicer_stable_releases"]` (version names sorted newest first,
+# with the latest release omitted).
+#
+# The list is rendered directly into the "Access Older Releases" version picker
+# on the download page (see download.markdown). Baking it into the generated
+# HTML at deploy time avoids performing a request to slicer-packages.kitware.com
+# from every visitor's browser on every page load.
+module Jekyll
+  class SlicerStableReleasesGenerator < Jekyll::Generator
+    # Run early so the data is available to every page during rendering.
+    priority :high
+
+    RELEASES_API_URL =
+      "https://slicer-packages.kitware.com/api/v1/app/5f4474d0e1d8c75dfc705482/release"
+
+    def generate(site)
+      versions = fetch_versions
+      # Drop the latest stable release; it is already offered in the main
+      # download table shown above the picker.
+      site.data["slicer_stable_releases"] = versions.drop(1)
+      Jekyll.logger.info "[SlicerStableReleases]:",
+                         "Fetched #{versions.length} stable release(s)."
+    rescue StandardError => e
+      Jekyll.logger.warn "[SlicerStableReleases]:",
+                         "Could not fetch stable releases (#{e.class}: #{e.message}); " \
+                         "the older-release picker will be rendered empty."
+      site.data["slicer_stable_releases"] = []
+    end
+
+    private
+
+    # Returns the release version names sorted in descending (newest first) order.
+    def fetch_versions
+      body = URI.parse(RELEASES_API_URL).open(open_timeout: 15, read_timeout: 30, &:read)
+      releases = JSON.parse(body)
+      releases
+        .map { |release| release["name"] }
+        .compact
+        .reject(&:empty?)
+        .sort { |a, b| compare_versions_desc(a, b) }
+    end
+
+    # Compares two version strings (e.g. "5.12.0", "4.11.20210226") numerically,
+    # returning a value suitable for a descending sort.
+    def compare_versions_desc(a, b)
+      pa = a.split(/[.-]/).map(&:to_i)
+      pb = b.split(/[.-]/).map(&:to_i)
+      [pa.length, pb.length].max.times do |i|
+        na = pa[i] || 0
+        nb = pb[i] || 0
+        return nb <=> na unless na == nb
+      end
+      0
+    end
+  end
+end

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -80,60 +80,10 @@ document.addEventListener('DOMContentLoaded', () => {
       releaseOsSelect.value = 'linux';
     }
 
-    // Compare two version strings (e.g. "5.12.0", "4.11.20210226") numerically, descending
-    const compareVersionsDesc = (a, b) => {
-      const pa = a.split(/[.-]/).map(Number);
-      const pb = b.split(/[.-]/).map(Number);
-      for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-        const na = pa[i] || 0;
-        const nb = pb[i] || 0;
-        if (na !== nb) {
-          return nb - na;
-        }
-      }
-      return 0;
-    };
-
-    // Populate the version combobox from the Slicer packages API.
-    // Deferred until the "Access Older Releases" tab is first opened, so the
-    // request is not made on every visit to the download page.
-    let versionsRequested = false;
-    const populateReleaseVersions = () => {
-      if (versionsRequested) {
-        return;
-      }
-      versionsRequested = true;
-      fetch('https://slicer-packages.kitware.com/api/v1/app/5f4474d0e1d8c75dfc705482/release')
-        .then(response => response.json())
-        .then(releases => {
-          const versions = releases
-            .map(release => release.name)
-            .filter(name => name)
-            .sort(compareVersionsDesc)
-            // Drop the latest stable release; it is already offered in the table above
-            .slice(1);
-          releaseVersionSelect.innerHTML = '';
-          versions.forEach(version => {
-            const option = document.createElement('option');
-            option.value = version;
-            option.textContent = 'Slicer ' + version;
-            releaseVersionSelect.appendChild(option);
-          });
-        })
-        .catch(() => {
-          // Allow a later tab visit to retry the request
-          versionsRequested = false;
-          releaseVersionSelect.innerHTML = '<option value="">Could not load versions</option>';
-        });
-    };
-
-    // Fetch the versions the first time the older-releases tab is opened.
-    // Clicking the tab fires this listener, including when the page auto-selects
-    // the tab from the URL fragment (#access-older-releases) further below.
-    const olderReleasesTab = document.getElementById('access-older-releases');
-    if (olderReleasesTab) {
-      olderReleasesTab.addEventListener('click', populateReleaseVersions);
-    }
+    // The list of versions is generated at build time and rendered directly
+    // into the <select> above (see download.markdown and the
+    // slicer_stable_releases Jekyll plugin), so no request to the Slicer
+    // packages API is made from the visitor's browser.
 
     // Navigate to the direct download URL for the selected version and OS
     releaseDownloadButton.addEventListener('click', (event) => {

--- a/download.markdown
+++ b/download.markdown
@@ -224,7 +224,11 @@ animated_navbar: false
                 <div class="control">
                     <div class="select is-small">
                         <select id="older-release-version" aria-label="Slicer version">
-                            <option value="">Loading versions…</option>
+                        {%- for version in site.data.slicer_stable_releases -%}
+                            <option value="{{ version }}">Slicer {{ version }}</option>
+                        {%- else -%}
+                            <option value="">Could not load versions</option>
+                        {%- endfor -%}
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
## Generate stable release list on deployment

Previously the "Access Older Releases" version picker fetched the release
list from `slicer-packages.kitware.com` in the visitor's browser on every
download-page visit. It's now generated once at build time.

### Changes
- **`_plugins/slicer_stable_releases.rb`** (new) — Jekyll generator that
  fetches the releases at build time, sorts them newest-first, drops the
  latest (already shown in the main table), and exposes the rest as
  `site.data["slicer_stable_releases"]`. Fails soft (warns, empty list) if
  the API is unreachable during the build.
- **`download.markdown`** — renders the `<option>`s from the build-time data
  via a Liquid loop, with a fallback option for the empty case.
- **`assets/js/app.js`** — removed the runtime `fetch()`, deferred-population
  logic, tab listener, and version-compare helper (~60 lines). OS
  pre-selection and download navigation unchanged.

### Trade-off
The list is static per deploy, so a newly published release appears in the
picker only after the next rebuild. Each deploy makes one API call per branch
instead of one per visitor.